### PR TITLE
Add Recording Message/Warning

### DIFF
--- a/classes/class.ilObjMultiVcGUI.php
+++ b/classes/class.ilObjMultiVcGUI.php
@@ -786,6 +786,14 @@ class ilObjMultiVcGUI extends ilObjectPluginGUI
             $my_tpl->setVariable("HIDE_GUESTLINK", 'hidden');
         }
 
+        // RECORDING MESSAGE
+        if( $this->object->get_moderated() ) {
+        if( $this->object->isRecordingAllowed() && ( $vcObj->isMeetingRunning() || $vcObj->isUserModerator() ) ) {
+            $my_tpl->setVariable("RECORDING_WARNING", $this->txt('recordung_warning'));
+        } 
+        } else {
+            $my_tpl->setVariable("HIDE_RECORDING_WARNING", 'hidden');
+        }
         // RECORDINGS
         if( $this->object->isRecordingAllowed() && $vcObj->isUserModerator() ) {
             $my_tpl->setVariable("HEADLINE_RECORDING", $this->txt('recording'));

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -55,6 +55,7 @@ private_chat_default#:#Privaten Chat erlauben: Voreinstellung
 private_chat_default_info#:#Sofern aktiviert, können auch Personen ohne Moderatorfunktion untereinander einen privaten Chat führen. Personen mit Moderatorfunktion sehen diese Chats nicht. Da Personen mit Moderatorfunktion jederzeit private Chats unterbinden können, solle diese Option in den meisten Fällen aktiviert sein.
 recording#:#Aufnahmen
 recording_info#:#Sitzungen können aufgenommen werden.
+recordung_warning#:#Für dieses Meeting wurde die Aufzeichnungsfunktion aktiviert! Mit der aktiven Nutzung des Chat-Systems, dem Einschalten meines persönlichen Mikrofons / meiner Kamera und/oder dem Teilen von Bildschirminhalten willige ich ein, dass diese Informationen bei der Aufzeichnung erfasst und für die spätere Verwendung im Rahmen der konkreten Lehrveranstaltung gespeichert werden.
 recording_choose#:#Aufnahmen erlauben: Auswahlmöglichkeit
 recording_choose_info#:#Aktivieren Sie diese Option, wenn Benutzer mit Schreibrechten unter Einstellungen die Auswahl 'Aufnahmen erlauben' haben sollen. Da bei Bekanntwerden der URL zur Aufnahme eine Verbreitung an nicht vorgesehene Personen gegeben ist, sollte diese Option in den meisten Fällen nicht aktiviert sein.
 recording_default#:#Aufnahmen erlauben: Voreinstellung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -55,6 +55,7 @@ private_chat_default#:#Allow private chat: Default setting
 private_chat_default_info#:#If activated, even people without moderator function can have a private chat with each other. Persons with moderator function do not see these chats. Since persons with moderator function can prevent private chats at any time, this option should be activated in most cases.
 recording#:#Recordings
 recording_info#:#Sessions can be recorded.
+recordung_warning#:#The recording function has been activated for this meeting! By actively using the chat system, turning on my personal microphone / camera and/or sharing screen content, I agree that this information will be captured during the recording and stored for later use in the context of the specific course.
 recording_choose#:#Allow recordings: Selection option
 recording_choose_info#:#Activate this option if you want users with write permissions to select 'Allow capturing' under Settings. Since the URL for the recording is known to be distributed to unintended persons, this option should not be activated in most cases.
 recording_default#:#Allow recordings: Default setting

--- a/templates/bbb/tpl.show_content_default.html
+++ b/templates/bbb/tpl.show_content_default.html
@@ -36,6 +36,8 @@
     </div>
 </div>
 
+<div id="recordingsallowed" class="col-sm-12 {HIDE_RECORDING_WARNING}">{RECORDING_WARNING}<br/>&nbsp;<br/></div>
+
 <div id="recordings" class="col-sm-12 {HIDE_RECORDINGS}">
     <h3 class="ilHeader">{HEADLINE_RECORDING}&nbsp;</h3>
     {RECORDINGS}</div>
@@ -70,4 +72,5 @@
 <style>
     #infotop { margin-bottom: 20px; }
     #info_concurrent { margin-bottom: 15px; }
+    #recordingsallowed { color: red; }
 </style>


### PR DESCRIPTION
A simple 'Warning' should be displayed as soon as recordings are active in the session.

The message is displayed as soon as recordings are active in the object. In addition, either the meeting must be active running or you must be the moderator.

Since the recording function can also be set when the room is unmoderated, another check is made.

I hope I have covered all possible variations.