### PR TITLE
Use correct configuration when starting new meeting

### DIFF
--- a/classes/class.ilApiBBB.php
+++ b/classes/class.ilApiBBB.php
@@ -528,9 +528,17 @@ class ilApiBBB implements ilApiInterface
             ->setAllowStartStopRecording($this->isMeetingRecordable())
             ->setRecord($this->isMeetingRecordable())
             ->setAutoStartRecording(false)
-            ->setWebcamsOnlyForModerator((bool) $this->object->isCamOnlyForModerator())
+            ->setWebcamsOnlyForModerator(
+                $this->settings->isCamOnlyForModeratorChoose()
+                ? (bool) $this->object->isCamOnlyForModerator()
+                : $this->settings->isCamOnlyForModeratorDefault()
+            )
             ->setLogoutUrl($joinBtnUrl)
-            ->setLockSettingsDisablePrivateChat(!(bool) $this->object->isPrivateChat())
+            ->setLockSettingsDisablePrivateChat(
+                $this->settings->isPrivateChatChoose()
+                ? !(bool) $this->object->isPrivateChat()
+                : !$this->settings->isPrivateChatDefault()
+            )
             ->setLogo(filter_var($this->settings->getLogo(), FILTER_SANITIZE_URL))
             ->setLockSettingsDisableCam(
                 !$this->settings->getLockDisableCamChoose()


### PR DESCRIPTION
Hello, we think that we discovered a bug. The steps to reproduce are:

1. We created a new room using a meeting type with "cam_only_for_moderator_default" enabled
2. We changed the setting of the meeting type
3. The setting is not applied when starting a meeting using this room

With this PR we try to fix this issue. Our proposed adjustments ensure that the settings are applied correctly.
We based our solution on the LockSettingsDisableCam setting.