### PR TITLE
Participant EventHandler Problem bei gelöschten Eltern-Objekten

### DIFF
--- a/classes/class.ilMultiVcConfig.php
+++ b/classes/class.ilMultiVcConfig.php
@@ -1354,7 +1354,15 @@ class ilMultiVcConfig
         return trim($value);
     }
 
+    public static function hasConnectionType(string $showcontent): bool
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
 
+        $result = $ilDB->query("SELECT showcontent FROM rep_robj_xmvc_conn where showcontent =  " . $ilDB->quote($showcontent, 'text'));
+        $row = $ilDB->fetchAssoc($result);
+        return !(null === $row);
+    }
 
 
 

--- a/classes/class.ilMultiVcPlugin.php
+++ b/classes/class.ilMultiVcPlugin.php
@@ -68,6 +68,8 @@ class ilMultiVcPlugin extends ilRepositoryObjectPlugin
     {
         global $DIC;
 
+        if (!ilMultiVcConfig::hasConnectionType('teams')) { return ; }
+
         $logger = $DIC->logger()->root();
         $tree = $DIC->repositoryTree();
 

--- a/classes/class.ilMultiVcPlugin.php
+++ b/classes/class.ilMultiVcPlugin.php
@@ -69,6 +69,7 @@ class ilMultiVcPlugin extends ilRepositoryObjectPlugin
         global $DIC;
 
         $logger = $DIC->logger()->root();
+        $tree = $DIC->repositoryTree();
 
         switch ($a_component) {
             case "Modules/Course":
@@ -78,6 +79,8 @@ class ilMultiVcPlugin extends ilRepositoryObjectPlugin
 
                     foreach ($ref_ids as $ref_id) {
                         $logger->debug('MultiVc: ' . $a_event . ' for RefId = ' . $ref_id . ' and UserId = ' . $a_parameter['usr_id']);
+                        if ($tree->isDeleted($ref_id)) { continue; }
+
                         //todo cache?
                         $xmvc_ref_ids = $DIC->repositoryTree()->getSubTree(
                             $DIC->repositoryTree()->getNodeData($ref_id),


### PR DESCRIPTION
In bestimmten Edge-Cases kann es passieren, dass der Event-Handler in https://github.com/Hufschmidt/MultiVc/blob/47a8ef0e050cf90ce1388ad4a847f56b8b50eda3/classes/class.ilMultiVcPlugin.php#L67 folgenden Fehler wirft:

```
[kfv1h] [2025-04-10 17:21:21.270269] mriliastest_root.ERROR: Whoops\Handler\CallbackHandler::handle:398 2
Undefined array key "path" in /srv/www/ilias/Services/Tree/classes/class.ilMaterializedPathTree.php:210
#0 /srv/www/ilias/Services/Init/classes/class.ilErrorHandling.php(451): 

Whoops\Run->handleError()
#1 /srv/www/ilias/Services/Tree/classes/class.ilMaterializedPathTree.php(210): ilErrorHandling->handlePreWhoops()
#2 /srv/www/ilias/Services/Tree/classes/class.ilTree.php(746): ilMaterializedPathTree->getSubTreeQuery()
#3 /srv/www/ilias/Customizing/global/plugins/Services/Repository/RepositoryObject/MultiVc/classes/class.ilMultiVcPlugin.php(82): ilTree->getSubTree()
#4 /srv/www/ilias/Services/EventHandling/classes/class.ilAppEventHandler.php(135): ilMultiVcPlugin->handleEvent()
#5 /srv/www/ilias/Services/Membership/classes/class.ilParticipants.php(856): ilAppEventHandler->raise()
#6 /srv/www/ilias/Modules/Group/classes/class.ilGroupParticipants.php(93): ilParticipants->add()
#7 /srv/www/ilias/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php(360): ilGroupParticipants->add()
#8 /srv/www/ilias/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php(192): ilECSCmsCourseMemberCommandQueueHandler->refreshAssignmentStatus()
#9 /srv/www/ilias/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php(99): ilECSCmsCourseMemberCommandQueueHandler->doUpdate()
#10 /srv/www/ilias/Services/WebServices/ECS/classes/class.ilECSTaskScheduler.php(192): ilECSCmsCourseMemberCommandQueueHandler->handleCreate()
#11 /srv/www/ilias/Services/WebServices/ECS/classes/class.ilECSTaskScheduler.php(85): ilECSTaskScheduler->handleEvents()
#12 /srv/www/ilias/webservice/soap/classes/class.ilSoapUtils.php(478): ilECSTaskScheduler->startTaskExecution()
#13 /srv/www/ilias/webservice/soap/include/inc.soap_functions.php(1084): ilSoapUtils->handleECSTasks()
#14 [internal function]: ilSoapFunctions::handleECSTasks()
#15 /srv/www/ilias/webservice/soap/server.php(50): SoapServer->handle()
#16 {main}  
```

## Ursache
Wenn ein `addParticipant` (oder `deleteParticipant`) Event durch den ECS ausgelöst wird und darin ein MultiVC-Objekt in einem gelöschten Objekt liegt (Papierkorb aktiv) läuft in diesem Fall der Aufruf von `$DIC->repositoryTree()->getSubTree` ins Leere.

### Beispiel

- ILIAS Kurs der per ECS erstellt wurde
  - Untergruppe die per ECS erstellt wurde
    -  MultiVC Objekt das hier durch Benutzer angelegt wurd

Löscht der Benutzer nun den ILIAS Kurs und erfolgt später eine Änderung die ein Mitglied im ILIAS-Kurs [1] hinzufügt oder entfernt wird obiger Fehler beim SubTree-Lookup der Untergruppe ausgelöst.

---
[1] Wenn man nur die Untergruppe löscht **scheint** der Fehler seltsamerweise nicht aufzutreten.

## Fix
Der PR enthält zwei Änderungen:
- Commit 1 prüft ob das Objekt mit der RefID im Papierkorb liegt bevor es im Baum gesucht wird und ist der primäre Fix.
- Commit 2 ist eine kleine Optimierung die den Event-Handler frühzeitig abbricht wenn ohnehin kein Teams konfiguriert ist.