### PR TITLE
MultiVc 9: Block meeting type deletion when objects still reference it

### DIFF
--- a/classes/class.ilMultiVcConfig.php
+++ b/classes/class.ilMultiVcConfig.php
@@ -1252,7 +1252,9 @@ class ilMultiVcConfig
         $data = array();
         while ($row = $ilDB->fetchAssoc($res)) {
             if ($a_extended) {
-                $row['usages'] = self::_countUntrashedUsages($row['id']);
+                $row['untrashed_usages'] = self::_countUntrashedUsages($row['id']);
+                $row['trashed_usages'] = self::_countTrashedUsages($row['id']);
+                $row['usages'] = self::_countAllUsages($row['id']);
             }
             $row['conn_id'] = $row['id'];
             unset($row['id']);
@@ -1277,6 +1279,43 @@ class ilMultiVcConfig
         $res = $ilDB->query($query);
         $row = $ilDB->fetchObject($res);
         return $row->untrashed;
+    }
+
+    /**
+     * Count the number of trashed usages of a type
+     */
+    public static function _countTrashedUsages(int $a_type_id): int
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+
+        $query = "SELECT COUNT(*) trashed FROM rep_robj_xmvc_data s"
+            . " INNER JOIN object_reference r ON s.id = r.obj_id"
+            . " WHERE r.deleted IS NOT NULL "
+            . " AND s.conn_id = " . $ilDB->quote($a_type_id, 'integer');
+
+        $res = $ilDB->query($query);
+        $row = $ilDB->fetchObject($res);
+        return $row->trashed;
+    }
+
+    /**
+     * Count all usages of a type (active and trashed)
+     */
+    public static function _countAllUsages(int $a_type_id): int
+    {
+        return self::_countUntrashedUsages($a_type_id) + self::_countTrashedUsages($a_type_id);
+    }
+
+    public static function connectionExists(int $connId): bool
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+
+        $set = $ilDB->query(
+            "SELECT id FROM rep_robj_xmvc_conn WHERE id = " . $ilDB->quote($connId, 'integer')
+        );
+        return (bool) $ilDB->fetchAssoc($set);
     }
 
     public static function _getMultiVcConnUsesReferences(int $connId): array

--- a/classes/class.ilMultiVcConfigGUI.php
+++ b/classes/class.ilMultiVcConfigGUI.php
@@ -297,9 +297,29 @@ class ilMultiVcConfigGUI extends ilPluginConfigGUI
         $this->dic->ui()->mainTemplate()->setContent($this->form->getHTML());
     }
 
-    private function deleteMultiVcConn()
+    private function getConnIdFromRequest(): int
     {
-        $this->object = ilMultiVcConfig::getInstance($this->dic->http()->wrapper()->query()->retrieve('conn_id', $this->dic->refinery()->kindlyTo()->int()));
+        return $this->dic->http()->wrapper()->query()->retrieve('conn_id', $this->dic->refinery()->kindlyTo()->int());
+    }
+
+    private function redirectOnDeleteWithUsages(int $connId): void
+    {
+        if (ilMultiVcConfig::_countAllUsages($connId) > 0) {
+            $this->dic->ui()->mainTemplate()->setOnScreenMessage(
+                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->dic->language()->txt('rep_robj_xmvc_conn_delete_blocked'),
+                true
+            );
+            $this->dic->ctrl()->redirect($this, 'configure');
+        }
+    }
+
+    private function deleteMultiVcConn(): void
+    {
+        $connId = $this->getConnIdFromRequest();
+        $this->redirectOnDeleteWithUsages($connId);
+
+        $this->object = ilMultiVcConfig::getInstance($connId);
 
         $gui = new ilConfirmationGUI();
         $gui->setFormAction($this->dic->ctrl()->getFormAction($this));
@@ -311,11 +331,12 @@ class ilMultiVcConfigGUI extends ilPluginConfigGUI
         $this->dic->ui()->mainTemplate()->setContent($gui->getHTML());
     }
 
-    private function deleteMultiVcConnConfirmed()
+    private function deleteMultiVcConnConfirmed(): void
     {
-        $this->object = ilMultiVcConfig::getInstance($this->dic->http()->wrapper()->query()->retrieve('conn_id', $this->dic->refinery()->kindlyTo()->int()));
+        $connId = $this->getConnIdFromRequest();
+        $this->redirectOnDeleteWithUsages($connId);
 
-        ilMultiVcConfig::_deleteMultiVcConn($this->dic->http()->wrapper()->query()->retrieve('conn_id', $this->dic->refinery()->kindlyTo()->int()));
+        ilMultiVcConfig::_deleteMultiVcConn($connId);
         $this->dic->ui()->mainTemplate()->setOnScreenMessage('success', $this->dic->language()->txt('rep_robj_xmvc_conn_deleted'), true);
         $this->dic->ctrl()->redirect($this, 'configure');
     }

--- a/classes/class.ilMultiVcConnTableGUI.php
+++ b/classes/class.ilMultiVcConnTableGUI.php
@@ -79,7 +79,16 @@ class ilMultiVcConnTableGUI extends ilTable2GUI
         $this->tpl->setVariable('TXT_ID', $a_set['conn_id']);
         $this->tpl->setVariable('TXT_TITLE', $a_set['title']);
         $this->tpl->setVariable('TXT_AVAILABILITY', $this->dic->language()->txt('rep_robj_xmvc_conf_availability_' . $a_set['availability']));
-        $this->tpl->setVariable('TXT_USAGES', (int) $a_set['usages']);
+        $usages = (int) ($a_set['usages'] ?? 0);
+        $trashedUsages = (int) ($a_set['trashed_usages'] ?? 0);
+        $usagesText = $trashedUsages > 0 ?
+            sprintf(
+                $this->dic->language()->txt('rep_robj_xmvc_usages_with_trash'),
+                $usages,
+                $trashedUsages
+            )
+            : (string) $usages;
+        $this->tpl->setVariable('TXT_USAGES', $usagesText);
 
         if($a_set['showcontent'] === 'webex' && $a_set['auth_method'] === 'admin') {
             $this->setWebex(true);

--- a/classes/class.ilObjMultiVc.php
+++ b/classes/class.ilObjMultiVc.php
@@ -155,15 +155,12 @@ class ilObjMultiVc extends ilObjectPlugin implements ilLPStatusPluginInterface
         $result = $ilDB->query("SELECT * FROM rep_robj_xmvc_data WHERE id = " . $ilDB->quote($this->getId(), "integer"));
         while ($record = $ilDB->fetchAssoc($result)) {
             $settings = new ilMultiVcConfig($record["conn_id"]);
-            if(!isset($settings->option)) {
-                //Meeting Type for a Virtual Meeting Object does not exist anymore
-                $this->dic->ui()->mainTemplate()->setOnScreenMessage('failure', $this->dic->language()->txt('error') . ': Meeting Type for a MultiVc Object does not exist anymore', true);
-                $this->dic->ctrl()->redirectToURL(ILIAS_HTTP_PATH);
+            if (isset($settings->option)) {
+                $this->option = $settings->option;
+                $this->setPrivateChat($settings->isPrivateChatDefault());
+                $this->setRecord($settings->isRecordDefault());
+                $this->setCamOnlyForModerator($settings->isCamOnlyForModeratorDefault());
             }
-            $this->option = $settings->option;
-            $this->setPrivateChat($settings->isPrivateChatDefault());
-            $this->setRecord($settings->isRecordDefault());
-            $this->setCamOnlyForModerator($settings->isCamOnlyForModeratorDefault());
             $this->setOnline($this->ilIntToBool($record["is_online"]));
             $this->set_token($record["token"]);
             $this->set_moderated($this->ilIntToBool($record["moderated"]));

--- a/classes/class.ilObjMultiVcAccess.php
+++ b/classes/class.ilObjMultiVcAccess.php
@@ -61,13 +61,19 @@ class ilObjMultiVcAccess extends ilObjectPluginAccess
             " WHERE id = " . $ilDB->quote($obj_id, "integer")
         );
         $data = $ilDB->fetchObject($set);
+        if (!is_object($data)) {
+            return false;
+        }
 
         $set = $ilDB->query(
             "SELECT availability FROM rep_robj_xmvc_conn " .
             " WHERE id = " . $ilDB->quote($data->conn_id, "integer")
         );
         $conn = $ilDB->fetchObject($set);
-        //var_dump([(int)ilMultiVcConfig::AVAILABILITY_NONE !== (int)$conn->availability, (int)$conn->availability]); exit;
+        if (!is_object($conn)) {
+            return false;
+        }
+
         return (int) ilMultiVcConfig::AVAILABILITY_NONE !== (int) $conn->availability;
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -76,6 +76,7 @@ conf_meeting_layout_4#:#VIDEO_FOCUS
 conf_meeting_layout#:#Meeting Layout
 conf_title#:#Titel
 conn_deleted#:#Der Meeting-Typ wurde gelöscht.
+conn_delete_blocked#:#Dieser Meeting-Typ kann nicht gelöscht werden, da noch Objekte ihn verwenden (einschließlich Objekte im Papierkorb).
 conn_id#:#Meeting-Typ
 copy#:#Kopieren
 create_type#:#Neuen Meeting-Typ definieren
@@ -408,6 +409,7 @@ token_stored#:#Token gespeichert
 unlocked_by#:#Freigegeben von
 unlock#:#Freigeben
 untrashed_usages#:#Anzahl Verwendungen
+usages_with_trash#:#%s (%s im Papierkorb)
 url_info#:#Hier können Sie auch relative Pfadangaben eintragen (z.B.: /webconference). Bitte am Ende kein '/' angeben.
 url#:#URL
 usage#:#Auslastung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -76,6 +76,7 @@ conf_meeting_layout_4#:#VIDEO_FOCUS
 conf_meeting_layout#:#Meeting layout
 conf_title#:#Title
 conn_deleted#:#The meeting type has been deleted.
+conn_delete_blocked#:#This meeting type cannot be deleted because objects still use it (including objects in trash).
 conn_id#:#Meeting type
 copy#:#Copy
 create_type#:#Define new meeting type
@@ -408,6 +409,7 @@ token_stored#:#Token stored
 unlocked_by#:#Unlocked by
 unlock#:#Unlock
 untrashed_usages#:#Number of uses
+usages_with_trash#:#%s (%s in trash)
 url_info#:#Here you can also enter relative paths (e.g.: /webconference). Please do not enter a '/' at the end.
 url#:#URL
 usage#:#Usage


### PR DESCRIPTION
Prevent deletion of meeting types still used by active or trashed MultiVc objects, show trashed usage counts in the connection table, and handle missing meeting types gracefully during object load and access checks.